### PR TITLE
Using HTTPoison.Base, and cleaning up some uneeded changes

### DIFF
--- a/lib/slackreceipt/xero.ex
+++ b/lib/slackreceipt/xero.ex
@@ -1,27 +1,22 @@
 defmodule SlackReceipt.Xero do
+  use HTTPoison.Base
+
   @consumer_key Application.get_env(:slackreceipt, :oauth)[:consumer_key]
   @consumer {@consumer_key, Application.get_env(:slackreceipt, :oauth)[:private_key_path], :rsa_sha1}
 
-  def get(url, params, headers \\ %{}), do: request(:get, url, params, "", headers)
-  def post(url, params, body \\ "", headers \\ %{}), do: request(:post, url, params, body, headers)
-  def put(url, params, body \\ "", headers \\ %{}), do: request(:put, url, params, body, headers)
-  def delete(url, params, headers \\ %{}), do: request(:delete, url, params, "", headers)
-
-  def request(method, url, params, body \\ %{}, headers \\ %{}) do
-
+  def request(method, url, params, body \\ %{}, headers \\ %{}, options \\ []) do
     # Creates signed params for oauth
     signed_params = :oauth.sign(
       Atom.to_string(method) |> String.upcase, url, params, @consumer, @consumer_key, ""
     )
 
-    # Creates headers
-    headers = Dict.merge(headers, %{
+    default_headers =  %{
       "Authorization": "OAuth #{:oauth.header_params_encode(signed_params)}",
       "Accept": "application/json"
-    }) |> Enum.reduce([], fn ({k,v}, a) -> 
-      a ++ [{Atom.to_string(k), v}]
-    end)
+    }
 
-    HTTPoison.request(method, url, "", headers)
+    headers = Map.merge(default_headers, headers)
+
+    super(method, url, "", headers, options)
   end
 end


### PR DESCRIPTION
1) HTTPoison.Base already defines get, post, put, delete and calls
request. I added a use HTTPoison.Base and overrided the request
method, and at the end called it directly. Since we need the
method in the headers definition there is no way around this.

2) Avoid using Dict.\* if possible. I changed it to just use
Map.merge, in this case it makes a huge difference because if
headers where a keyword list the merge would be O(n^2).
Luckily for us you expect a map from the caller and we can assume
you will be the caller so map it is!

3) HTTPoison will also convert Headers from a map to a list see
https://github.com/edgurgel/httpoison/blob/master/lib/httpoison/base.ex#L91
so we can skip that step.

I don't have the xero key so I couldn't test this locally but it
builds!
